### PR TITLE
전반적인 코드 리팩토링

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,4 +78,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    implementation "androidx.activity:activity-ktx:1.5.0"
 }

--- a/app/src/main/java/com/example/dagger_exam/MainActivity.kt
+++ b/app/src/main/java/com/example/dagger_exam/MainActivity.kt
@@ -1,22 +1,26 @@
 package com.example.dagger_exam
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.widget.Toast
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.dagger_exam.databinding.ActivityMainBinding
-import com.example.dagger_exam.model.RecyclerList
+import javax.inject.Inject
 
 class MainActivity : AppCompatActivity() {
-
     lateinit var binding : ActivityMainBinding
 
+    @Inject
+    lateinit var viewModelFactory: MainActivityViewModel.Factory
+
     private lateinit var recyclerViewAdapter: RecyclerViewAdapter
-    private lateinit var mainActivityViewModel: MainActivityViewModel
+    private val mainActivityViewModel by viewModels<MainActivityViewModel> { viewModelFactory }
+
+    private val component get() = (application as MyApplication).retroComponent
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        component.inject(this)
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -25,27 +29,21 @@ class MainActivity : AppCompatActivity() {
         initViewModel()
     }
 
-
-
     private fun initRecyclerView(){
-        binding.recyc.layoutManager = LinearLayoutManager(this)
         recyclerViewAdapter = RecyclerViewAdapter()
+        binding.recyc.layoutManager = LinearLayoutManager(this)
         binding.recyc.adapter = recyclerViewAdapter
     }
 
     private fun initViewModel(){
-        mainActivityViewModel= ViewModelProvider(this).get(MainActivityViewModel::class.java)
-        mainActivityViewModel.getLiveDataObserver().observe(this, object : Observer<RecyclerList>{
-            override fun onChanged(t: RecyclerList?) {
-                if(t != null){
-                    recyclerViewAdapter.setupdatedData(t.items)
-                    recyclerViewAdapter.notifyDataSetChanged()
-                }else{
-                    Toast.makeText(this@MainActivity,"error",Toast.LENGTH_SHORT).show()
-
-                }
+        mainActivityViewModel.liveDataList.observe(this) { items ->
+            if (items != null) {
+                recyclerViewAdapter.listData = items.items
+                recyclerViewAdapter.notifyDataSetChanged()
+            } else {
+                Toast.makeText(this@MainActivity, "error", Toast.LENGTH_SHORT).show()
             }
-        })
-        mainActivityViewModel.makeApicall()
+        }
+        mainActivityViewModel.makeApiCall()
     }
 }

--- a/app/src/main/java/com/example/dagger_exam/MainActivityViewModel.kt
+++ b/app/src/main/java/com/example/dagger_exam/MainActivityViewModel.kt
@@ -1,50 +1,47 @@
 package com.example.dagger_exam
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import com.example.dagger_exam.di.RetroServiceInterface
 import com.example.dagger_exam.model.RecyclerList
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import javax.inject.Inject
+import javax.inject.Provider
 
-class MainActivityViewModel(application: Application) : AndroidViewModel(application) {
+class MainActivityViewModel @Inject constructor(
+    private val retrofitService: RetroServiceInterface
+) : ViewModel() {
+    private val _liveDataList: MutableLiveData<RecyclerList> = MutableLiveData()
+    val liveDataList: LiveData<RecyclerList> get() = _liveDataList
 
+    fun makeApiCall() {
+        val call: Call<RecyclerList>? = retrofitService.getDataFromAPI("atl")
 
-    @Inject
-    lateinit var mService : RetroServiceInterface
-
-    private lateinit var liveDataList: MutableLiveData<RecyclerList>
-
-
-    init{
-        //here we need to init application.
-        (application as MyApplication).getRetroComponent().inject(this)
-        liveDataList = MutableLiveData()
-    }
-
-    fun getLiveDataObserver(): MutableLiveData<RecyclerList>{
-        return liveDataList
-    }
-
-    fun makeApicall(){
-       val call : Call<RecyclerList>? = mService.getDataFromAPI("atl")
-        call?.enqueue(object : Callback<RecyclerList>{
+        call?.enqueue(object : Callback<RecyclerList> {
             override fun onFailure(call: Call<RecyclerList>, t: Throwable) {
-                liveDataList.postValue(null)
+                _liveDataList.postValue(null)
             }
 
             override fun onResponse(call: Call<RecyclerList>, response: Response<RecyclerList>) {
-               if(response.isSuccessful){
-                   liveDataList.postValue(response.body())
-               }else{
-                   liveDataList.postValue(null)
-               }
-
+                if (response.isSuccessful) {
+                    _liveDataList.postValue(response.body())
+                } else {
+                    _liveDataList.postValue(null)
+                }
             }
-
         })
+    }
+
+    class Factory @Inject constructor(
+        private val mainActivityViewModelProvider: Provider<MainActivityViewModel>
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return mainActivityViewModelProvider.get() as T
+        }
     }
 }

--- a/app/src/main/java/com/example/dagger_exam/MyApplication.kt
+++ b/app/src/main/java/com/example/dagger_exam/MyApplication.kt
@@ -6,12 +6,9 @@ import com.example.dagger_exam.di.DaggerRetroComponent
 import com.example.dagger_exam.di.RetroComponent
 import com.example.dagger_exam.di.RetroModule
 
-
-
-class MyApplication : Application(){
-
-
-    private lateinit var retroComponent: RetroComponent
+class MyApplication : Application() {
+    lateinit var retroComponent: RetroComponent
+        private set
 
     override fun onCreate() {
         super.onCreate()
@@ -19,9 +16,5 @@ class MyApplication : Application(){
         retroComponent = DaggerRetroComponent.builder()
             .retroModule(RetroModule())
             .build()
-    }
-
-    fun getRetroComponent(): RetroComponent {
-        return retroComponent
     }
 }

--- a/app/src/main/java/com/example/dagger_exam/RecyclerViewAdapter.kt
+++ b/app/src/main/java/com/example/dagger_exam/RecyclerViewAdapter.kt
@@ -1,7 +1,6 @@
 package com.example.dagger_exam
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -10,35 +9,25 @@ import com.example.dagger_exam.databinding.RecyclerViewListBinding
 import com.example.dagger_exam.model.RecyclerData
 
 class RecyclerViewAdapter : RecyclerView.Adapter<RecyclerViewAdapter.MyViewHolder>() {
+    var listData: List<RecyclerData>? = null
 
-    private var listData : List<RecyclerData>? = null
+    class MyViewHolder(private val binding: RecyclerViewListBinding) :
+        RecyclerView.ViewHolder(binding.root) {
 
-
-    fun setupdatedData(listData:List<RecyclerData>){
-        this.listData = listData
-    }
-
-    class MyViewHolder(private val binding:RecyclerViewListBinding): RecyclerView.ViewHolder(binding.root){
-
-        val imageView = binding.ImageView
-        val textName = binding.textName
-        val textdescription =binding.textdescription
-
-        fun bind(data : RecyclerData){
-            textName.setText(data.name)
-            textdescription.setText(data.description)
+        fun bind(data: RecyclerData) = with(binding) {
+            textName.text = data.name
+            textDescription.text = data.description
 
             Glide.with(imageView)
                 .load(data.owner?.avatar_url)
                 .apply(RequestOptions.centerCropTransform())
                 .into(imageView)
         }
-
-
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyViewHolder {
-      val binding = RecyclerViewListBinding.inflate(LayoutInflater.from(parent.context),parent,false)
+        val binding =
+            RecyclerViewListBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return MyViewHolder(binding)
     }
 
@@ -47,7 +36,7 @@ class RecyclerViewAdapter : RecyclerView.Adapter<RecyclerViewAdapter.MyViewHolde
     }
 
     override fun getItemCount(): Int {
-        if(listData == null )return 0
-        else return listData?.size!!
+        return if (listData == null) 0
+        else listData?.size!!
     }
 }

--- a/app/src/main/java/com/example/dagger_exam/di/RetroComponent.kt
+++ b/app/src/main/java/com/example/dagger_exam/di/RetroComponent.kt
@@ -1,12 +1,11 @@
 package com.example.dagger_exam.di
 
-import com.example.dagger_exam.MainActivityViewModel
+import com.example.dagger_exam.MainActivity
 import dagger.Component
 import javax.inject.Singleton
 
 @Singleton
 @Component(modules = [RetroModule::class])
 interface RetroComponent {
-
-    fun inject(mainActivityViewModel: MainActivityViewModel)
+    fun inject(activity: MainActivity)
 }

--- a/app/src/main/java/com/example/dagger_exam/di/RetroModule.kt
+++ b/app/src/main/java/com/example/dagger_exam/di/RetroModule.kt
@@ -8,18 +8,17 @@ import javax.inject.Singleton
 
 @Module
 class RetroModule {
-
-    val baseURL = "https://api.github.com/search/"
+    private val baseURL = "https://api.github.com/search/"
 
     @Singleton
     @Provides
-    fun getRetroServiceInterface(retrofit: Retrofit) : RetroServiceInterface{
+    fun getRetroServiceInterface(retrofit: Retrofit): RetroServiceInterface {
         return retrofit.create(RetroServiceInterface::class.java)
     }
 
     @Singleton
     @Provides
-    fun getRetroFitInstacnce(): Retrofit{
+    fun getRetroFitInstance(): Retrofit {
         return Retrofit.Builder()
             .baseUrl(baseURL)
             .addConverterFactory(GsonConverterFactory.create())

--- a/app/src/main/java/com/example/dagger_exam/di/RetroServiceInterface.kt
+++ b/app/src/main/java/com/example/dagger_exam/di/RetroServiceInterface.kt
@@ -7,7 +7,6 @@ import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface RetroServiceInterface {
-
     @GET("repositories")
-    fun getDataFromAPI(@Query("q")query: String): Call<RecyclerList>?
+    fun getDataFromAPI(@Query("q") query: String): Call<RecyclerList>?
 }

--- a/app/src/main/java/com/example/dagger_exam/model/RecyclerList.kt
+++ b/app/src/main/java/com/example/dagger_exam/model/RecyclerList.kt
@@ -1,6 +1,6 @@
 package com.example.dagger_exam.model
 
 
-data class RecyclerList(val items : List<RecyclerData>)
-data class RecyclerData(val name:String?, val description:String?,val owner: Owner?)
-data class Owner(val avatar_url : String?)
+data class RecyclerList(val items: List<RecyclerData>)
+data class RecyclerData(val name: String?, val description: String?, val owner: Owner?)
+data class Owner(val avatar_url: String?)

--- a/app/src/main/res/layout/recycler_view_list.xml
+++ b/app/src/main/res/layout/recycler_view_list.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:orientation="horizontal"
     android:layout_height="wrap_content">
 
 
     <ImageView
-        android:id="@+id/ImageView"
+        android:id="@+id/imageView"
         android:layout_gravity="center"
         android:layout_marginStart="10dp"
         android:layout_width="80dp"
-        android:layout_height="80dp" />
+        android:layout_height="80dp"
+        tools:ignore="ContentDescription" />
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -26,7 +28,7 @@
             android:textColor="@color/black"/>
 
         <TextView
-            android:id="@+id/textdescription"
+            android:id="@+id/textDescription"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="10dp"


### PR DESCRIPTION
MainActivityViewModel에 Dagger Component가 아닌 RetroServiceInterface를 주입받도록 수정
MainActivityViewModel의 MutableLiveData가 아닌 LiveData를 public으로 변경
필요없는 getter, setter function 삭제
오타 및 coding convention에 맞게 수정
